### PR TITLE
Removes hacky code

### DIFF
--- a/addon/components/sortable-items.js
+++ b/addon/components/sortable-items.js
@@ -132,24 +132,14 @@ var SortableItems = Ember.Component.extend({
       var freezeSelector = this.get('freeze');
       collection.removeAt(evt.oldIndex);
       collection.insertAt(evt.newIndex, item);
-      // Remove the duplicate
-      evt.item.parentNode.removeChild(evt.item);
 
       if (freezeSelector) {
-        var duplicates = 0;
         frozenObjects.forEach(function(obj, i) {
           var pos = positions[i];
           if (collection.objectAt(pos) !== obj) {
             var realPos = collection.indexOf(obj);
             collection.removeAt(realPos);
             collection.insertAt(pos, obj);
-            // Remove the duplicate
-            if (realPos > pos) {
-              list.children[pos - 1 - duplicates].remove();
-            } else {
-              list.children[pos + duplicates].remove();
-            }
-            duplicates++;
           }
         });
       }


### PR DESCRIPTION
I'm honestly not sure why, but the code for removing duplicates is no longer necessary.
I think this has to do with RubaXa's Sortable library upgrading, but in any case keeping this code causes items to be disappear when moved.
